### PR TITLE
Add support for WAMR

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,5 +21,7 @@ jobs:
     # Because of the special "install LLVM" task, we need to specify which tools to use.
     - name: Build components
       run: make
-    - name: Run benchmark
+    - name: Run benchmark - Wasmtime
       run: make benchmark
+    - name: Run benchmark - WAMR
+      run: make benchmark.wamr

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "zlib/src"]
 	path = zlib/src
 	url = https://github.com/madler/zlib
+[submodule "wasm-micro-runtime/src"]
+	path = wasm-micro-runtime/src
+	url = https://github.com/bytecodealliance/wasm-micro-runtime

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ PIGZ_WASM=pigz/pigz.wasm
 ZLIB_WASM=zlib/libz.wasm.a
 WASI_SDK_CC=wasi-sdk/bin/clang
 WASMTIME=wasmtime/src/target/release/wasmtime
+WAMR=wasm-micro-runtime/src/build/iwasm
 
 # Compile and link the various WebAssembly objects and the Wasmtime engine to run them. Important
 # variables:
@@ -20,21 +21,32 @@ $(WASI_SDK_CC):
 $(WASMTIME):
 	make -C wasmtime
 
+# Compile WASM micro runtime. Configuration variables:
+# - WAMR_PLATFORM: modify the build platform for WASM micro runtime (default - linux).
+$(WAMR):
+	make -C wasm-micro-runtime
+
 clean:
 	make -C wasi-sdk clean
 	make -C zlib clean
 	make -C pigz clean
 	make -C wasmtime clean
+	make -C wasm-micro-runtime clean
 	rm -f random.*
 
-# Run the pigz WebAssembly binary as a CLI application using Wasmtime; this is not meant to be a
-# highly-accurate benchmarking setup but rather a quick check that things work. Because pigz will
-# remove the original file, we keep an `.original.bin` copy around for replicatability.
+# Run the pigz WebAssembly binary as a CLI application using Wasmtime (or WASM micro runtime);
+# this is not meant to be a highly-accurate benchmarking setup but rather a quick check
+# that things work. Because pigz will remove the original file, we keep an `.original.bin` copy
+# around for replicatability.
 NUM_THREADS ?= 1
 benchmark: random.bin $(PIGZ_WASM) $(WASMTIME)
 	@rm -f random.bin.gz
 	time $(WASMTIME) --dir . --wasm-features=threads --wasi-modules=experimental-wasi-threads \
 		$(PIGZ_WASM) -- -p $(NUM_THREADS) /random.bin
+	@gzip --decompress --stdout random.bin.gz >/dev/null
+benchmark.wamr: random.bin $(PIGZ_WASM) $(WAMR)
+	@rm -f random.bin.gz
+	time $(WAMR) --max-threads=$(shell echo ${NUM_THREADS}+1 | bc) --dir=. $(PIGZ_WASM) -p $(NUM_THREADS) /random.bin
 	@gzip --decompress --stdout random.bin.gz >/dev/null
 random.bin: random.original.bin
 	@cp $< $@

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ wasm-parallel-gzip
 
 This project demonstrates how to build and run parallel compression using WebAssembly and
 [wasi-threads]. It compiles the [pigz] CLI tool to WebAssembly using a [wasi-sdk] pre-release and
-runs it using a recent version of [wasmtime]. At the moment, wasi-threads is still [experimental];
-though its ABI is unstable, this demo motivates the need for spawning threads in WebAssembly.
+runs it using a recent version of [wasmtime] (and optionally, [wamr]). At the moment, wasi-threads
+is still [experimental]; though its ABI is unstable, this demo motivates the need for spawning
+threads in WebAssembly.
 
 [experimental]: https://github.com/WebAssembly/wasi-threads/issues/10
 [wasi-threads]: https://github.com/WebAssembly/wasi-threads
@@ -39,7 +40,8 @@ tool:
 [wasi-sdk]: wasi-sdk
 [wasmtime]: wasmtime
 [zlib]: zlib
-[release]: https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20%2Bthreads
+[wamr]: wasm-micro-runtime
+[release]: https://github.com/WebAssembly/wasi-sdk/releases/tag/wasi-sdk-20
 
 ### Run
 
@@ -48,6 +50,15 @@ make benchmark
 ```
 
 Run parallel compression (by default, `NUM_THREADS=1`) on a randomly-generated file.
+
+### Running benchmarks using WASM micro runtime
+`make benchmark` command uses Wasmtime engine to run the benchmark. Use the following
+command to build WASM micro runtime (for linux platform) and run benchmarks (in the fast
+interpreter mode):
+
+```
+make benchmark.wamr WAMR_PLATFORM=linux
+```
 
 ### TODO
 

--- a/wasi-sdk/Makefile
+++ b/wasi-sdk/Makefile
@@ -1,11 +1,11 @@
 # Download and unpack wasi-sdk.
 
-bin/clang-16: wasi-sdk-20.0.threads-linux.tar.gz
-	tar --extract --verbose --touch --strip-components=1 --file=wasi-sdk-20.0.threads-linux.tar.gz
+bin/clang-16: wasi-sdk-20.0-linux.tar.gz
+	tar --extract --verbose --touch --strip-components=1 --file=wasi-sdk-20.0-linux.tar.gz
 
-wasi-sdk-20.0.threads-linux.tar.gz:
-	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20%2Bthreads/$@
+wasi-sdk-20.0-linux.tar.gz:
+	wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-20/$@
 	touch $@
 
 clean:
-	rm -rf wasi-sdk-20.0.threads-linux.tar.gz wasi-sdk-20.0+threads
+	rm -rf wasi-sdk-20.0-linux.tar.gz wasi-sdk-20.0

--- a/wasm-micro-runtime/Makefile
+++ b/wasm-micro-runtime/Makefile
@@ -1,0 +1,11 @@
+WAMR_PLATFORM?=linux
+
+# Build WASM Micro Runtime.
+build/iwasm:
+	cd src && mkdir -p build && cd build && \
+		cmake -DCMAKE_BUILD_TYPE=Release -DWAMR_BUILD_LIB_WASI_THREADS=1 ../product-mini/platforms/$(WAMR_PLATFORM)/ && \
+		cmake --build .
+
+# Note that we also need to clean up the Git tree as well.
+clean:
+	cd src && cmake --build build --target clean && git restore .


### PR DESCRIPTION
I thought it'd be good to have WAMR additionally to wasmtime here as it's also a bytecodealliance's project.

I know the repo serves as an example for building and running multi-threaded applications so if you think WAMR support shouldn't be here, I'm ok dropping that commit and only keep the `Update WASI sdk to release (insteade of pre-release) version` one.